### PR TITLE
Patch#2

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -24,15 +24,15 @@ yamlLoader('src/syntaxes/_index.yaml', (err, res) => {
 
   const yamlString = res.buffer
   const pojo = encodeObject(YAML.parse(yamlString))
-  const jsonString = JSON.stringify(pojo, null, 4)
+  const jsonString = JSON.stringify(YAML.parse(yamlString), null, 4)
   const plistString = plist.build(pojo)
   const builds = [
     ['build/syntaxes/ManiaScript.YAML-tmLanguage', yamlString],
-    ['build/syntaxes/ManiaScript.JSON-tmLanguage', jsonString],
+    ['build/syntaxes/ManiaScript.json', jsonString],
     ['build/syntaxes/ManiaScript.tmLanguage', plistString]
   ]
 
   builds.forEach(([path, buffer]) => 
-    fs.writeFile(path, buffer, 'utf8', 
+    fs.writeFileSync(path, buffer, 'utf8', 
       console.log(chalk.yellow('write'), chalk.green(`${path}... done!`))))
 })

--- a/src/syntaxes/literal-template-string.YAML-tmLanguage
+++ b/src/syntaxes/literal-template-string.YAML-tmLanguage
@@ -11,4 +11,5 @@ literal-template-string:
             name: string.template-string.ms
             patterns:
                 - {include: '#template-string-content'}
+                - {include: 'text.xml'}
                 - {begin: '{{{', beginCaptures: {'0': {name: punctuation.template-string.element.begin.ms}}, end: '}}}', endCaptures: {'0': {name: punctuation.template-string.element.end.ms}}, name: entity.template-string.element.ms, patterns: [{include: '#expression'}]}

--- a/src/syntaxes/template-string-content.YAML-tmLanguage
+++ b/src/syntaxes/template-string-content.YAML-tmLanguage
@@ -10,11 +10,12 @@ template-string-content:
             patterns:
                 - {include: '#expression'}
         -
-            begin: '(<script><!--|<script>)'
+            name: meta.embedded.script.block.ms
+            begin: '(<script><!--|<script><\!\[CDATA\[|<script>)'
             beginCaptures:
                 '0': {name: meta.brace.tag.script.open.ms}
                 '1': {name: punctuation.tag.script.open.ms}
-            end: '(--><\/script>|<\/script>)'
+            end: '(--><\/script>|\]\]<\/script>|<\/script>)'
             endCaptures:
                 '0': {name: meta.brace.tag.script.close.ms}
                 '1': {name: punctuation.tag.script.close.ms}


### PR DESCRIPTION
Fix deprecation warning on `npm run build`.
Adding adding vscode xml highliter for template strings (as you usually write inside json or manialink xml).
Allow  <![CDATA[ escaped scripts... as well as add name for script elements to embed vscode language.